### PR TITLE
removed react and react-dom from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "iojs": ">= 3.0",
     "npm": ">= 2.1"
   },
+  "dependencies": {},
   "devDependencies": {
     "babel": "5.8.23",
     "babel-eslint": "^4.1.0",
@@ -36,11 +37,9 @@
     "eslint": "^1.3.1",
     "eslint-plugin-react": "^3.3.0",
     "react-hot-loader": "^1.3.0",
+    "react": "^0.14.0-rc1",
+    "react-dom": "^0.14.0-rc1",
     "webpack": "^1.12.0",
     "webpack-dev-server": "^1.10.1"
-  },
-  "dependencies": {
-    "react": "^0.14.0-rc1",
-    "react-dom": "^0.14.0-rc1"
   }
 }


### PR DESCRIPTION
Moved `react` and `react-dom` from dependencies to devDependencies, for those using newer versions of react its imported twice in project, causing this error:

```
Uncaught Invariant Violation: addComponentAsRefTo(...): Only a ReactOwner can have refs. You might be adding a ref to a component that was not created inside a component's `render` method, or you have multiple copies of React loaded (details: https://fb.me/react-refs-must-have-owner).
```

here's the tree structure when you do `npm ls | grep react` more details [here](https://fb.me/react-refs-must-have-owner)

``` ssh
├─┬ react@15.0.0-rc.2
├── react-dom@15.0.0-rc.2
├─┬ react-flexbox@3.0.0
│ ├─┬ react@0.14.7
│ ├─┬ react-dom@0.14.7
```
