### PR TITLE
Strip props that should not be set on a div (Fixes #11)

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -59,6 +59,14 @@ export default class View extends Component {
     if (this.props.auto) {
       style.flex = '0 0 auto';
     }
-    return <div {...this.props} style={style}>{this.props.children}</div>;
+
+    // strip props that are invalid to set on a div.
+    // (prevents https://fb.me/react-unknown-prop)
+    let {
+      row, column, auto,
+      ...divProps
+    } = this.props;
+
+    return <div {...divProps} style={style}>{this.props.children}</div>;
   }
 }


### PR DESCRIPTION
Prevents the `row`, `column` and `auto` props being passed down to the DOM element because these are invalid attributes and cause [this warning](https://fb.me/react-unknown-prop)

Addresses #11 
